### PR TITLE
Fix #262: Remove `present` from invocation scheme and keep it generic

### DIFF
--- a/conformance-specs/cs-02-credential-presentation.md
+++ b/conformance-specs/cs-02-credential-presentation.md
@@ -140,7 +140,7 @@ The request MUST be integrity‑protected (JAR‑style or equivalent).
 The Verifier redirects the user-agent to the WU using:
 
 ```
-openid4vp://present?request_uri=<URL>
+openid4vp://?request_uri=<URL>
 ```
 
 Wallet retrieves or validates the signed Presentation Request Object.
@@ -246,7 +246,7 @@ Wallets MUST:
 
 1. Support HAIP‑compliant OpenID4VP.
 2. Support the same‑device and cross‑device flows.
-3. Support openid4vp://present invocation.
+3. Support invocation via the `openid4vp://` custom URL scheme.
 4. Validate signed Presentation Requests.
 5. Implement SD‑JWT‑VC selective disclosure.
 6. Provide transparent Holder consent.
@@ -304,7 +304,7 @@ Example:
 
 
 ```
-openid4vp://present?request_uri=https://verifier.example.org/request/123
+openid4vp://?request_uri=https://verifier.example.org/request/123
 ```
 
 


### PR DESCRIPTION
Closes #262. Removes the non-normative `present` authority from the `openid4vp://` invocation URI in §6.1.2, §7.1 and §8.1, leaving the bare `openid4vp://` scheme that OpenID4VP defines.