### PR TITLE
Add type vocabulary and reframe the §4 decision tree

### DIFF
--- a/blueprint/04-integration-model.md
+++ b/blueprint/04-integration-model.md
@@ -168,3 +168,32 @@ Some WE BUILD scenarios involve interactions between backend systems rather than
 This is particularly relevant for EBW scenarios such as supply chain credentials, Digital Product Passports, and automated B2B or B2G data exchange. In such cases, credential issuance and presentation may be initiated by backend systems while still following the interoperability patterns defined in this blueprint.
 
 Although the interaction is system-driven, the same trust framework, credential formats, and verification mechanisms apply as in user-driven wallet interactions.
+
+## Decision tree
+
+The following decision tree guides implementers in choosing between an EAA (including QEAA and PuB-EAA), the WE BUILD QERDS, and existing enterprise IT integrations.
+
+Its starting point is the user's need in the flow, which maps to the two capabilities the wallet provides. Sharing **trust** means issuing or presenting an *attestation* — an issuer-asserted, verifiable claim. Sharing **content** means delivering a *document* or *record* to a counterparty as a *message*. The two are orthogonal, so a flow that needs both — for example, a QEAA that must also be delivered with legal effect — applies the tree once per need. All type terms are defined in the glossary.
+
+```mermaid
+flowchart TD
+  need(["User need in the flow"]) --> what{{"What must the user share?"}}
+  what -->|"Trust — a verifiable claim (an attestation)"| who{{"Who must be able to rely on it?"}}
+  what -->|"Content — a document or record, delivered as a message"| deliver{{"Does delivery itself need legal effect?"}}
+
+  %% Trust / attestation branch
+  who -->|"Any relying party, under EU rules"| effect{{"Does issuing the attestation<br/>change the parties' legal position?"}}
+  who -->|"A known counterparty, by agreement"| bilateral["Agreed method<br/>(trust already established —<br/>outside wallet scope)"]
+  effect -->|"Yes — issuing is the act"| constitutive["EAA (constitutive)"]
+  effect -->|"No — an earlier act, held<br/>in an authoritative source"| suffice{{"Attributes alone, or must the<br/>source record stay traceable?"}}
+  suffice -->|"Attributes suffice"| derived["EAA (derived)"]
+  suffice -->|"Source record must stay traceable"| ref["EAA (derived) + reference to the record"]
+
+  %% Content / delivery branch
+  deliver -->|"Yes — proof of send/receipt matters"| regime{{"Is the channel already<br/>governed by a sectoral regime?"}}
+  deliver -->|"No — ordinary or agreed exchange"| ordinary["Existing channel<br/>(outside wallet scope)"]
+  regime -->|"No regime governs the channel"| qerds["QERDS message (notification / submission)"]
+  regime -->|"A sectoral regime governs it"| sectoral["That regime's channel"]
+```
+
+**Data** is the substrate carried by both branches — the attributes an attestation asserts and the content a document holds — so it is not a branch of its own. The two *outside wallet scope* leaves (bilateral trust, ordinary exchange) are the patterns the wallet's trust and delivery capabilities are intended to improve on.

--- a/blueprint/04-integration-model.md
+++ b/blueprint/04-integration-model.md
@@ -173,27 +173,28 @@ Although the interaction is system-driven, the same trust framework, credential 
 
 The following decision tree guides implementers in choosing between an EAA (including QEAA and PuB-EAA), the WE BUILD QERDS, and existing enterprise IT integrations.
 
-Its starting point is the user's need in the flow, which maps to the two capabilities the wallet provides. Sharing **trust** means issuing or presenting an *attestation* — an issuer-asserted, verifiable claim. Sharing **content** means delivering a *document* or *record* to a counterparty as a *message*. The two are orthogonal, so a flow that needs both — for example, a QEAA that must also be delivered with legal effect — applies the tree once per need. All type terms are defined in the glossary.
+Its starting point is the user's need in the flow, which maps to the two capabilities the wallet provides. **Proving a claim** means issuing or presenting an *EAA* — an issuer-asserted, independently verifiable claim. **Sharing information** means delivering a *business document* or *record* to a counterparty as a *message*. As a rule of thumb, an EAA is suitable wherever a zero-knowledge proof could suffice — proving something without transferring the underlying document; everything else needs a data-transfer mechanism. The two paths are orthogonal, so a flow that needs both — for example, a QEAA that must also be delivered with legal effect — applies the tree once per need. All type terms are defined in the glossary.
 
 ```mermaid
 flowchart TD
-  need(["User need in the flow"]) --> what{{"What must the user share?"}}
-  what -->|"Trust — a verifiable claim (an attestation)"| who{{"Who must be able to rely on it?"}}
-  what -->|"Content — a document or record, delivered as a message"| deliver{{"Does delivery itself need legal effect?"}}
+  need(["User need in the flow"]) --> what{{"What must the user do?"}}
 
-  %% Trust / attestation branch
-  who -->|"Any relying party, under EU rules"| effect{{"Does issuing the attestation<br/>change the parties' legal position?"}}
-  who -->|"A known counterparty, by agreement"| bilateral["Agreed method<br/>(trust already established —<br/>outside wallet scope)"]
+  what -->|"Prove a claim (an EAA)"| who{{"Who must be able to rely on it?"}}
+  what -->|"Share information (a business document or record)"| deliver{{"Does delivery itself need legal effect?"}}
+
+  %% EAA branch
+  who -->|"Any relying party, under EU rules"| effect{{"Does issuing the EAA<br/>change the parties' legal position?"}}
+  who -->|"A known counterparty, by agreement"| bilateral["Agreed method<br/>(bilateral relationship —<br/>outside wallet scope)"]
   effect -->|"Yes — issuing is the act"| constitutive["EAA (constitutive)"]
   effect -->|"No — an earlier act, held<br/>in an authoritative source"| suffice{{"Attributes alone, or must the<br/>source record stay traceable?"}}
   suffice -->|"Attributes suffice"| derived["EAA (derived)"]
   suffice -->|"Source record must stay traceable"| ref["EAA (derived) + reference to the record"]
 
-  %% Content / delivery branch
+  %% Information / delivery branch
   deliver -->|"Yes — proof of send/receipt matters"| regime{{"Is the channel already<br/>governed by a sectoral regime?"}}
   deliver -->|"No — ordinary or agreed exchange"| ordinary["Existing channel<br/>(outside wallet scope)"]
   regime -->|"No regime governs the channel"| qerds["QERDS message (notification / submission)"]
   regime -->|"A sectoral regime governs it"| sectoral["That regime's channel"]
 ```
 
-**Data** is the substrate carried by both branches — the attributes an attestation asserts and the content a document holds — so it is not a branch of its own. The two *outside wallet scope* leaves (bilateral trust, ordinary exchange) are the patterns the wallet's trust and delivery capabilities are intended to improve on.
+**Data** is the substrate carried by both branches — the attributes an EAA asserts and the content a business document holds — so it is not a branch of its own. An EAA is itself an *electronic document*; a *business document* is an electronic document that is not an EAA. The two *outside wallet scope* leaves (bilateral relationship, ordinary exchange) are the patterns the wallet's EAA and QERDS capabilities are intended to improve on.

--- a/blueprint/05-data-and-semantics.md
+++ b/blueprint/05-data-and-semantics.md
@@ -2,7 +2,7 @@
 
 While the previous chapter describes how wallets interact with services, this chapter describes the data and semantic structures used inside the wallet and in the exchanged attestations.
 
-The types of information the wallet handles — data, document, record, message and attestation — are defined in the glossary; this chapter describes how the meaning of that information is modelled.
+The types of information the wallet handles — data, electronic and business documents, records, messages and EAAs — are defined in the glossary; this chapter describes how the meaning of that information is modelled.
 
 ## Semantic Model of the European Business Wallet
 

--- a/blueprint/05-data-and-semantics.md
+++ b/blueprint/05-data-and-semantics.md
@@ -2,6 +2,8 @@
 
 While the previous chapter describes how wallets interact with services, this chapter describes the data and semantic structures used inside the wallet and in the exchanged attestations.
 
+The types of information the wallet handles — data, document, record, message and attestation — are defined in the glossary; this chapter describes how the meaning of that information is modelled.
+
 ## Semantic Model of the European Business Wallet
 
 The semantic model is organised into three layers:

--- a/blueprint/appendix-glossary.md
+++ b/blueprint/appendix-glossary.md
@@ -10,9 +10,12 @@ While this document avoids abbreviations as much as possible, commonly used abbr
 | :--- | :--- | :--- |
 | **Architectural Decision Record** | ADR | A document used to capture and justify significant technical choices. ADRs serve as the project’s "logbook" to ensure transparency regarding the rationale behind protocol and standard adoption. |
 | **Architecture and Reference Framework** | ARF | The reference architecture for the European Digital Identity Wallet ecosystem published by the European Commission in cooperation with the Member States. It defines roles, trust models, protocols and interoperability requirements for the ecosystem. |
+| **Attestation** | — | An issuer-asserted, independently verifiable claim about a subject. In the EBW ecosystem, attestations are expressed as Electronic Attestations of Attributes (see *EAA / QEAA / PuB-EAA*). |
 | **Attestation Rulebook**| - | A document describing the governance, requirements and semantic interpretation of a specific attestation type, including how credential data maps to vocabulary terms and schemas. |
 | **Blueprint** | — | The high-level architecture and integration document (D4.1) describing the WE BUILD ecosystem, architectural patterns, interaction flows and governance model. |
 | **Business Wallet Unit Attestation** | BWUA | A specific type of Wallet Unit Attestation issued for a European Business Wallet (EBW) instance. |
+| **Data** | — | Facts represented in a formalised, machine-processable form, independent of any container or evidential role; the base layer that documents contain and attestations carry as attributes. |
+| **Document** | — | A bounded container of content in electronic form (text, sound, visual or audiovisual). A *structured document* is one whose content is also machine-actionable data (e.g. a Peppol BIS invoice). |
 | **EAA Provider** | — | An entity that relies on authentic sources of information to issue attestations to a wallet. |
 | **EBW Instance** | — | A unique deployment or installation of a European Business Wallet (EBW) solution, controlled by an Owner (legal person or economic operator). |
 | **EBW Provider** | — | A Wallet Provider specifically authorized to issue and manage European Business Wallets (EBW). |
@@ -33,12 +36,14 @@ While this document avoids abbreviations as much as possible, commonly used abbr
 | <del>**Legal Person Identification Data**</del> | LPID | See **EBW Owner Identification Data** instead. |
 | **Level of Assurance** | LoA | A classification of the degree of confidence in the electronic identification of a natural person, a legal person, or a natural person representing a legal person. Recognised levels are: Low, Substantial, High. |
 | **List of Trusted Lists** | LoTL | A list that references national or ecosystem Trusted Lists, allowing participants to discover and validate trusted entities. |
+| **Message** | — | A transport-level envelope carrying content between parties, distinct from its payload. In WE BUILD, legal-grade delivery of messages is provided through QERDS. |
 | **Natural Person** | — | An individual human being acting in their own capacity. |
 | **Owner** | — | The legal person or economic operator that has legal control over and responsibility for an EBW Instance. |
 | **Personal Identification Data** | PID | A mandatory set of attributes issued to a natural person to uniquely identify them at Level of Assurance (LoA) High. |
 | **PID Provider** | — | An entity responsible for verifying the identity of a natural person and issuing Personal Identification Data (PID). |
 | **Qualified Electronic Registered Delivery Service** | QERDS | A secure communication channel that provides legal evidence of the handling of transmitted data. |
 | **Qualified Trust Service Provider** | QTSP | A regulated entity providing electronic trust services (e.g., signatures, seals, or delivery services) with full legal effect under eIDAS. |
+| **Record** | — | A document or data retained as evidence of an activity or obligation, with fixity, context and retention; defined by its evidential role and lifecycle, not its format. |
 | **Relying Party** | RP | An entity that requests and receives attestations from a wallet to verify specific attributes or identities. |
 | **Selective Disclosure JSON Web Token** | SD-JWT | A format allowing holders to share only specific parts of a credential while keeping other data private. |
 | **Trust Framework** | — | The set of governance rules, standards, and trust infrastructure used to establish and verify trust relationships between ecosystem participants. |

--- a/blueprint/appendix-glossary.md
+++ b/blueprint/appendix-glossary.md
@@ -10,12 +10,11 @@ While this document avoids abbreviations as much as possible, commonly used abbr
 | :--- | :--- | :--- |
 | **Architectural Decision Record** | ADR | A document used to capture and justify significant technical choices. ADRs serve as the project’s "logbook" to ensure transparency regarding the rationale behind protocol and standard adoption. |
 | **Architecture and Reference Framework** | ARF | The reference architecture for the European Digital Identity Wallet ecosystem published by the European Commission in cooperation with the Member States. It defines roles, trust models, protocols and interoperability requirements for the ecosystem. |
-| **Attestation** | — | An issuer-asserted, independently verifiable claim about a subject. In the EBW ecosystem, attestations are expressed as Electronic Attestations of Attributes (see *EAA / QEAA / PuB-EAA*). |
 | **Attestation Rulebook**| - | A document describing the governance, requirements and semantic interpretation of a specific attestation type, including how credential data maps to vocabulary terms and schemas. |
 | **Blueprint** | — | The high-level architecture and integration document (D4.1) describing the WE BUILD ecosystem, architectural patterns, interaction flows and governance model. |
+| **Business document** | — | A document exchanged in a business transaction whose content is asserted by a party within a process (e.g. an invoice, despatch advice, catalogue). Distinct from an EAA: it is not an issuer-asserted, independently verifiable claim. |
 | **Business Wallet Unit Attestation** | BWUA | A specific type of Wallet Unit Attestation issued for a European Business Wallet (EBW) instance. |
-| **Data** | — | Facts represented in a formalised, machine-processable form, independent of any container or evidential role; the base layer that documents contain and attestations carry as attributes. |
-| **Document** | — | A bounded container of content in electronic form (text, sound, visual or audiovisual). A *structured document* is one whose content is also machine-actionable data (e.g. a Peppol BIS invoice). |
+| **Data** | — | Facts represented in a formalised, machine-processable form, independent of any container or evidential role; the base layer that documents contain and EAAs carry as attributes. |
 | **EAA Provider** | — | An entity that relies on authentic sources of information to issue attestations to a wallet. |
 | **EBW Instance** | — | A unique deployment or installation of a European Business Wallet (EBW) solution, controlled by an Owner (legal person or economic operator). |
 | **EBW Provider** | — | A Wallet Provider specifically authorized to issue and manage European Business Wallets (EBW). |
@@ -23,6 +22,7 @@ While this document avoids abbreviations as much as possible, commonly used abbr
 | **EBW Owner Identification Data** | EBWOID | A set of attributes used to uniquely identify a legal person or economic operator within the European Business Wallet ecosystem. |
 | **Economic operator** | — | Any natural or legal person or public entity which offers products or services on the market; the primary user of the European Business Wallet. |
 | **Electronic Attestation of Attributes** | EAA / QEAA / PuB-EAA | Digital credentials that prove specific attributes (e.g., professional qualifications, representation rights) with either qualified (QEAA) or public sector body-issued (PuB-EAA) or non-qualified (EAA) legal status. |
+| **Electronic document** | — | A bounded container of content in electronic form (text, sound, visual or audiovisual); also referred to as a *digital document*. The generic concept, which also covers an EAA. A *structured document* is one whose content is also machine-actionable data (e.g. a Peppol BIS invoice). |
 | **Electronic Identification, Authentication and Trust Services** | eIDAS / eIDAS 2.0 | The legal framework for electronic identification and trust services for electronic transactions in the European Single Market. |
 | **European Business Wallet** | EBW | A wallet designed for economic operators or public sector bodies to manage business data such as mandates, electronic invoices, and administrative and professional documents and notifications. |
 | **European Digital Identity Wallet** | EUDI Wallet | A mobile or cloud-based solution for natural persons to manage and share identity data. |


### PR DESCRIPTION
Followup on Sanders PR #283 as a separate PR as I suggest changes to the glossary as well, and that these definitions are worthy of a separate discussion.

- Glossary: add Data, Electronic document (generic; also covers an EAA), Business document (non-EAA), Message, Record. No generic Attestation — EAA stays the controlled term.
- §4 decision tree: trunk reframed from "Data to share" to user-need-first: Prove a claim (EAA) vs Share information (business document/record). 
- §5: one pointer to the glossary; chapter stays about the semantic model.