### PR TITLE
Add notice text

### DIFF
--- a/blueprint/_quarto.yml
+++ b/blueprint/_quarto.yml
@@ -16,7 +16,7 @@ website:
     type: overlay
   page-footer:
     left: |
-      ![EU](eu.png){width=200px} ![WE BUILD](/we_build.png){width=200px}
+      ![EU](eu.png){width=200px} ![WE BUILD](/we_build.png){width=200px} <br>[WE BUILD](https://www.webuildconsortium.eu/) is co-funded by the European Union. However, the views and opinions expressed are those of the author(s) only and do not necessarily reflect those of the European Union or the granting authority. Neither the European Union nor the granting authority can be held responsible.
   navbar:
     background: light
     collapse-below: lg


### PR DESCRIPTION
Adds the following text to the bottom-left notice:

[WE BUILD](https://www.webuildconsortium.eu/) is co-funded by the European Union. However, the views and opinions expressed are those of the author(s) only and do not necessarily reflect those of the European Union or the granting authority. Neither the European Union nor the granting authority can be held responsible.

<img width="631" height="393" alt="image" src="https://github.com/user-attachments/assets/e5274b01-413f-4f39-88b4-43fa6745d813" />

Fixes #112