### PR TITLE
fix: correct typos in `cs-04` and `cs-05` examples regarding key attestations

### DIFF
--- a/conformance-specs/cs-04-wua-lifecycle.md
+++ b/conformance-specs/cs-04-wua-lifecycle.md
@@ -415,7 +415,7 @@ Where each element comes from:
 JOSE header:
 
 ```json
-{ "alg": "ES256", "typ": "keyattestation+jwt", "x5c": ["<wallet provider signing certificate chain>"] }
+{ "alg": "ES256", "typ": "key-attestation+jwt", "x5c": ["<wallet provider signing certificate chain>"] }
 ```
 
 Payload:
@@ -437,6 +437,7 @@ Payload:
 
 Where each element comes from:
 - `alg` (ES256, ES384 or ES512) - TS-03 [3], clause 2.6.
+- `typ` (`key-attestation+jwt`) - OpenID4VCI [5], Appendix D.1
 - `attested_keys`, `key_storage`, `certification`, `key_storage_status` - TS-03 [3], clause 2.3.2.
 - `user_authentication` - OpenID4VCI [5], Appendix D, as referenced by TS-03 [3], clause 2.3.2.
 - Signing a `jwt` proof with the key at index 0 of `attested_keys` - TS-03 [3], clause 2.2.2.1.

--- a/conformance-specs/cs-05-bwua-lifecycle.md
+++ b/conformance-specs/cs-05-bwua-lifecycle.md
@@ -626,7 +626,7 @@ JOSE header:
 ```json
 {
   "alg": "ES256",
-  "typ": "keyattestation+jwt",
+  "typ": "key-attestation+jwt",
   "x5c": ["<Business Wallet Provider signing certificate chain>"]
 }
 ```
@@ -651,6 +651,7 @@ Payload:
 Where each element comes from:
 
 - `alg` (ES256, ES384 or ES512) - TS3 [3], clause 2.6, as required by section 7.1.
+- `typ` (`key-attestation+jwt`) - OpenID4VCI [5], Appendix D.1
 - `attested_keys`, `key_storage`, `certification` and `key_storage_status` - TS3 [3], clause 2.3.2, applied to a cloud- or organisation-controlled HSM rather than a device WSCD.
 - `user_authentication` - OpenID4VCI [5], Appendix D, as referenced by TS3 [3], clause 2.3.2. For a business wallet it expresses the authentication level applied to the administrator or user operating the BWU (section 4), not that of a single device holder.
 - `key_storage_status.status` (type-shared or per-SKA index) - TS3 [3], clause 2.5.2, using the Token Status List [9], as required by section 7.2.


### PR DESCRIPTION
Fixes #312 and partially resolves #270.